### PR TITLE
Feature: Support producing a full build, with native tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -187,6 +187,11 @@ WINDOWS_COMPILER_OPTIONS = {
 
 #Additional libs to build for webrtc and ortc targets
 TARGETS_TO_BUILD = {
+                                'default' : (
+                                              [
+                                                'default'
+                                              ],1
+                                ),
                                 'webrtc'  : (
                                               [ 
                                                 'webrtc',
@@ -253,6 +258,10 @@ WEBRTC_WRAPPER_PROJECTS = [
 NUGET_WINUWP_WEBRTC_SOLUTION = 'WebRtc.Wrapper.Universal.sln'
 
 TARGET_WRAPPER_SOLUTIONS = {
+                              'default': {
+                                            'winuwp' : 'WebRtc.Wrapper.Universal.sln',
+                                            'net' : '',
+                                          },
                               'webrtc' :  {
                                             'winuwp' : 'WebRtc.Wrapper.Universal.sln',
                                             'net' : '',
@@ -266,6 +275,10 @@ TARGET_WRAPPER_SOLUTIONS = {
 WEBRTC_WRAPPER_PROJECTS_OUTPUT_PATH = './webrtc/windows/solutions/Build/Output/Org.WebRtc'
 
 TARGET_WRAPPER_PROJECTS_OUTPUT_PATHS = {
+                                          'default' :  {
+                                                        'winuwp' : './webrtc/windows/solutions/Build/Output/Org.WebRtc',
+                                                        'net' : '',
+                                                      },
                                           'webrtc' :  {
                                                         'winuwp' : './webrtc/windows/solutions/Build/Output/Org.WebRtc',
                                                         'net' : '',

--- a/config.py
+++ b/config.py
@@ -187,11 +187,6 @@ WINDOWS_COMPILER_OPTIONS = {
 
 #Additional libs to build for webrtc and ortc targets
 TARGETS_TO_BUILD = {
-                                'default' : (
-                                              [
-                                                'default'
-                                              ],1
-                                ),
                                 'webrtc'  : (
                                               [ 
                                                 'webrtc',
@@ -258,10 +253,6 @@ WEBRTC_WRAPPER_PROJECTS = [
 NUGET_WINUWP_WEBRTC_SOLUTION = 'WebRtc.Wrapper.Universal.sln'
 
 TARGET_WRAPPER_SOLUTIONS = {
-                              'default': {
-                                            'winuwp' : 'WebRtc.Wrapper.Universal.sln',
-                                            'net' : '',
-                                          },
                               'webrtc' :  {
                                             'winuwp' : 'WebRtc.Wrapper.Universal.sln',
                                             'net' : '',
@@ -275,10 +266,6 @@ TARGET_WRAPPER_SOLUTIONS = {
 WEBRTC_WRAPPER_PROJECTS_OUTPUT_PATH = './webrtc/windows/solutions/Build/Output/Org.WebRtc'
 
 TARGET_WRAPPER_PROJECTS_OUTPUT_PATHS = {
-                                          'default' :  {
-                                                        'winuwp' : './webrtc/windows/solutions/Build/Output/Org.WebRtc',
-                                                        'net' : '',
-                                                      },
                                           'webrtc' :  {
                                                         'winuwp' : './webrtc/windows/solutions/Build/Output/Org.WebRtc',
                                                         'net' : '',

--- a/defaults.py
+++ b/defaults.py
@@ -63,7 +63,7 @@ supportedCPUsForPlatform = {
                             }
 
 #List of targets for which will be performed specified actions. Supported target is webrtc. In future it will be added support for ortc.
-targets = [ 'webrtc', 'default' ]
+targets = [ 'webrtc' ]
 #List of target cpus. Supported cpus are arm, x86 and x64
 targetCPUs = [ 'arm', 'x86', 'x64' ]
 #List of target platforms. Supported cpus are win and winuwp

--- a/defaults.py
+++ b/defaults.py
@@ -63,7 +63,7 @@ supportedCPUsForPlatform = {
                             }
 
 #List of targets for which will be performed specified actions. Supported target is webrtc. In future it will be added support for ortc.
-targets = [ 'webrtc' ]
+targets = [ 'webrtc', 'default' ]
 #List of target cpus. Supported cpus are arm, x86 and x64
 targetCPUs = [ 'arm', 'x86', 'x64' ]
 #List of target platforms. Supported cpus are win and winuwp
@@ -89,7 +89,10 @@ actions = [ 'prepare', 'build' ]
 
 buildWithClang = False
 #Flag if wrapper library should be built. If it is False, it will be built only native libraries
-buildWrapper = True  
+buildWrapper = True
+
+#Flag if rtc_include_tests should be defined. If False, native tests aren't built
+includeTests = False
 
 #=========== cleanupOptions
 #'actions' : ['cleanOutput', 'cleanIdls', 'cleanUserDef','cleanPrepare'],

--- a/inputHandler.py
+++ b/inputHandler.py
@@ -18,7 +18,7 @@ class Input:
     if System.checkIfTargetIsSupported('ortc'):
       parser.add_argument('-t','--targets', nargs='*', choices=['ortc', 'webrtc'], help='Target')
     else:
-      parser.add_argument('-t','--targets', nargs='*', choices=['webrtc', 'default'], help='Target')
+      parser.add_argument('-t','--targets', nargs='*', choices=['webrtc'], help='Target')
     
     if System.hostOs == 'mac':
       parser.add_argument('-p','--platforms', nargs='*', choices=['mac', 'iOS'], help='Target platform')

--- a/inputHandler.py
+++ b/inputHandler.py
@@ -18,7 +18,7 @@ class Input:
     if System.checkIfTargetIsSupported('ortc'):
       parser.add_argument('-t','--targets', nargs='*', choices=['ortc', 'webrtc'], help='Target')
     else:
-      parser.add_argument('-t','--targets', nargs='*', choices=['webrtc'], help='Target')
+      parser.add_argument('-t','--targets', nargs='*', choices=['webrtc', 'default'], help='Target')
     
     if System.hostOs == 'mac':
       parser.add_argument('-p','--platforms', nargs='*', choices=['mac', 'iOS'], help='Target platform')
@@ -44,6 +44,8 @@ class Input:
     parser.add_argument('--setnugetkey', nargs='?', action='store', dest='setnugetkey', help='Set the api key for the nuget server')
 
     parser.add_argument('-u','--userTarget', nargs='?', help='Target to build if not webrtc or ortc')
+
+    parser.add_argument('--includeTests', action='store_true', help='Include webrtc native tests (rtc_include_tests=true)')
     
     parser.add_argument('--setservernoteversion', action='store_true', help='Set release notes version from latest nuget package on nuget.org')
     

--- a/prepare.py
+++ b/prepare.py
@@ -99,6 +99,17 @@ class Preparation:
 
     cls.logger.info('Runnning preparation for target: ' + target + '; platform: ' + platform + '; cpu: ' + cpu + '; configuration: ' + configuration)
 
+    # if we're trying to do a full build, we need some resources
+    if target == 'default':
+      rcPath = os.path.join(Settings.webrtcPath, 'build/toolchain/win')
+      status = System.downloadFromGoogle('chromium-browser-clang/rc', rcPath, True, True)
+      if not status:
+        ret = errors.ERROR_PREPARE_DOWNLOADING_TOOLS_FAILED
+      resourcesPath = os.path.join(Settings.webrtcPath, 'resources')
+      status = System.downloadFromGoogle('chromium-webrtc-resources', resourcesPath, True, True)
+      if not status:
+        ret = errors.ERROR_PREPARE_DOWNLOADING_TOOLS_FAILED
+
     #Change working directory
     Utility.pushd(Settings.webrtcPath)
 
@@ -159,7 +170,7 @@ class Preparation:
       with open(argsPath) as argsFile:
         cls.logger.debug('Updating args.gn file. Target OS: ' + platform + '; Target CPU: ' + cpu)
         newArgs=argsFile.read().replace('-target_os-', platform).replace('-target_cpu-', cpu)
-        newArgs=newArgs.replace('-is_debug-',str(configuration.lower() == 'debug').lower()).replace('-is_clang-',bool_to_str(Settings.buildWithClang).lower())
+        newArgs=newArgs.replace('-is_debug-',str(configuration.lower() == 'debug').lower()).replace('-is_clang-',bool_to_str(Settings.buildWithClang).lower()).replace('-is_include_tests-', bool_to_str(Settings.includeTests).lower())
       with open(argsPath, 'w') as argsFile:
         argsFile.write(newArgs)
     except Exception as error:

--- a/settings.py
+++ b/settings.py
@@ -134,6 +134,12 @@ class Settings:
     else:
       cls.buildWrapper = buildWrapper
 
+    #If configurations are passed like input arguments use them, instead of one loaded from template
+    if cls.inputArgs.includeTests:
+      cls.includeTests = True
+    else:
+      cls.includeTests = includeTests
+
     cls.stopExecutionOnError = stopExecutionOnError
     cls.showTraceOnError = showTraceOnError
     cls.showSettingsValuesOnError = showSettingsValuesOnError

--- a/system.py
+++ b/system.py
@@ -348,7 +348,7 @@ class System:
       Ortc is supported if ortc folder exists in sdk root
     """
     #Webrtc is always supported
-    cls.supportedTargets = ['webrtc']
+    cls.supportedTargets = ['webrtc', 'default']
     
     #If ortc folder exists in sdk root folder add ortc in the list of supported targets
     if os.path.exists(os.path.join(Settings.rootSdkPath,'ortc')):
@@ -378,12 +378,39 @@ class System:
     """
     ret = True
 
+    result = cls.downloadFromGoogle('chromium-' + toolName, os.path.join(Settings.localBuildToolsPath,toolName + '.exe.sha1'), False, False)
+
+    if not result:
+      ret = False
+      cls.logger.error('Failed downloading ' + toolName)
+    
+    return ret
+
+  @classmethod
+  def downloadFromGoogle(cls, bucket, path, isDirectory = False, shouldRecurse = True):
+    """
+      Download content from the google storage buckets
+      :param bucket: the name of the google bucket to download from
+      :param path: the path to a sha1 file OR the path to a directory containing sha1 files
+      :param isDirectory: must be True is path is a file, and False if path is a directory
+      :param shouldRecurse: only used if path is a directory, True to recursively scan for sha1 files, False to not
+      :return ret: True if successfully downloaded.
+    """
+    ret = True
+
+    #TODO(bengreenier): we can and should derive isDirectory
+
     #Temporary change working directory to local depot tools path
     Utility.pushd(Settings.localDepotToolsPath)
     
-    cls.logger.info('Downloading build tool ' + toolName + '...')
-    #Download tool
-    cmd = 'python download_from_google_storage.py --bucket chromium-' + toolName + ' -s ' + os.path.join(Settings.localBuildToolsPath,toolName + '.exe.sha1')
+    operationDetails = path + ' from bucket \'' + bucket
+    cls.logger.info('Downloading ' + operationDetails + '\'...')
+
+    #Run download
+    flag = '-d' if isDirectory else '-s'
+    modifier = '-r' if shouldRecurse else ''
+    cmd = 'python download_from_google_storage.py --bucket ' + bucket + ' ' + flag + ' ' + path + ' ' + modifier
+
     result = Utility.runSubprocess([cmd], Settings.logLevel == 'DEBUG')
 
     #Switch to previous working directory
@@ -391,7 +418,7 @@ class System:
 
     if result != NO_ERROR:
       ret = False
-      cls.logger.error('Failed downloading ' + toolName)
+      cls.logger.error('Failed downloading ' + operationDetails)
     
     return ret
 

--- a/system.py
+++ b/system.py
@@ -384,7 +384,7 @@ class System:
       Ortc is supported if ortc folder exists in sdk root
     """
     #Webrtc is always supported
-    cls.supportedTargets = ['webrtc', 'default']
+    cls.supportedTargets = ['webrtc']
     
     #If ortc folder exists in sdk root folder add ortc in the list of supported targets
     if os.path.exists(os.path.join(Settings.rootSdkPath,'ortc')):

--- a/system.py
+++ b/system.py
@@ -318,6 +318,42 @@ class System:
         ret = errors.ERROR_SYSTEM_FAILED_DELETING_USERDEF
       
     return ret
+
+  @classmethod
+  def downloadFromGoogle(cls, bucket, path, isDirectory = False, shouldRecurse = True):
+    """
+      Download content from the google storage buckets
+      :param bucket: the name of the google bucket to download from
+      :param path: the path to a sha1 file OR the path to a directory containing sha1 files
+      :param isDirectory: must be True is path is a file, and False if path is a directory
+      :param shouldRecurse: only used if path is a directory, True to recursively scan for sha1 files, False to not
+      :return ret: True if successfully downloaded.
+    """
+    ret = True
+
+    #TODO(bengreenier): we can and should derive isDirectory
+
+    #Temporary change working directory to local depot tools path
+    Utility.pushd(Settings.localDepotToolsPath)
+    
+    operationDetails = path + ' from bucket \'' + bucket
+    cls.logger.info('Downloading ' + operationDetails + '\'...')
+
+    #Run download
+    flag = '-d' if isDirectory else '-s'
+    modifier = '-r' if shouldRecurse else ''
+    cmd = 'python download_from_google_storage.py --bucket ' + bucket + ' ' + flag + ' ' + path + ' ' + modifier
+
+    result = Utility.runSubprocess([cmd], Settings.logLevel == 'DEBUG')
+
+    #Switch to previous working directory
+    Utility.popd()
+
+    if result != NO_ERROR:
+      ret = False
+      cls.logger.error('Failed downloading ' + operationDetails)
+    
+    return ret
   #---------------------------------- Private methods --------------------------------------------
   @classmethod
   def __createUserDefFile(cls):
@@ -383,42 +419,6 @@ class System:
     if not result:
       ret = False
       cls.logger.error('Failed downloading ' + toolName)
-    
-    return ret
-
-  @classmethod
-  def downloadFromGoogle(cls, bucket, path, isDirectory = False, shouldRecurse = True):
-    """
-      Download content from the google storage buckets
-      :param bucket: the name of the google bucket to download from
-      :param path: the path to a sha1 file OR the path to a directory containing sha1 files
-      :param isDirectory: must be True is path is a file, and False if path is a directory
-      :param shouldRecurse: only used if path is a directory, True to recursively scan for sha1 files, False to not
-      :return ret: True if successfully downloaded.
-    """
-    ret = True
-
-    #TODO(bengreenier): we can and should derive isDirectory
-
-    #Temporary change working directory to local depot tools path
-    Utility.pushd(Settings.localDepotToolsPath)
-    
-    operationDetails = path + ' from bucket \'' + bucket
-    cls.logger.info('Downloading ' + operationDetails + '\'...')
-
-    #Run download
-    flag = '-d' if isDirectory else '-s'
-    modifier = '-r' if shouldRecurse else ''
-    cmd = 'python download_from_google_storage.py --bucket ' + bucket + ' ' + flag + ' ' + path + ' ' + modifier
-
-    result = Utility.runSubprocess([cmd], Settings.logLevel == 'DEBUG')
-
-    #Switch to previous working directory
-    Utility.popd()
-
-    if result != NO_ERROR:
-      ret = False
-      cls.logger.error('Failed downloading ' + operationDetails)
     
     return ret
 


### PR DESCRIPTION
We needed a way to build complete webrtc trees and wanted to do so using this wrapper, _and_ to conditionally compile the tests as well. This is my proposed solution for supporting that.

+ Add `default` target, named after the webrtc target `default`
+ Add `--includeTests` flag, which controls the `rtc_include_tests` value in the `args.gn` template (separate change - link incoming)
+ Download missing resources for full builds when `prepare` runs for `default`
+ Validated on a clean enlistment

> Note: currently building `default` with `--includeTests` for platform `winuwp` does not work and will fail - this appears to be because some of the tests depend on things that aren't there in `winuwp`

Looking for feedback __especially__ on the name `default` for this new target...since it isn't the default of this wrapper running...but is instead the matching name in the core webrtc source.