### PR TITLE
Add option to force C++17 on Win32 MSVC

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -49,6 +49,7 @@ targetProgrammingLanguage = [ 'cx', 'cppwinrt', 'c', 'dotnet', 'python' ]
 actions = [ 'prepare', 'build' ]
 
 buildWithClang = False
+buildWithCpp17 = False
 #Flag if wrapper library should be built. If it is False, it will be built only native libraries
 buildWrapper = True
 

--- a/inputHandler.py
+++ b/inputHandler.py
@@ -39,6 +39,8 @@ class Input:
     
     parser.add_argument('--clang', action='store_true', help='Build with clang')
     
+    parser.add_argument('--cpp17', action='store_true', help='Build with /std:c++17')
+    
     parser.add_argument('--prerelease', nargs='?', action='store', dest='cmdPrerelease', help='Set the prerelease for the created nuget package')
 
     parser.add_argument('--uploadurl', nargs='?', action='store', dest='uploadBackupURL', help='Cloud storrage URL to wich backup will be uploaded')

--- a/prepare.py
+++ b/prepare.py
@@ -174,7 +174,10 @@ class Preparation:
       with open(argsPath) as argsFile:
         cls.logger.debug('Updating args.gn file. Target OS: ' + platform + '; Target CPU: ' + cpu)
         newArgs=argsFile.read().replace('-target_os-', platform).replace('-target_cpu-', cpu)
-        newArgs=newArgs.replace('-is_debug-',str(configuration.lower() == 'debug').lower()).replace('-is_clang-',bool_to_str(Settings.buildWithClang).lower()).replace('-is_include_tests-', bool_to_str(Settings.includeTests).lower())
+        newArgs=newArgs.replace('-is_debug-',str(configuration.lower() == 'debug').lower())
+        newArgs=newArgs.replace('-is_clang-',bool_to_str(Settings.buildWithClang).lower())
+        newArgs=newArgs.replace('-std_cpp17-',bool_to_str(Settings.buildWithCpp17).lower())
+        newArgs=newArgs.replace('-is_include_tests-', bool_to_str(Settings.includeTests).lower())
       with open(argsPath, 'w') as argsFile:
         argsFile.write(newArgs)
     except Exception as error:

--- a/settings.py
+++ b/settings.py
@@ -115,6 +115,11 @@ class Settings:
     else:
       cls.buildWithClang = buildWithClang
 
+    if cls.inputArgs.cpp17:
+      cls.buildWithCpp17 = True
+    else:
+      cls.buildWithCpp17 = buildWithCpp17
+
     cls.buildWrapper = buildWrapper
 
     cls.logFormat = logFormat


### PR DESCRIPTION
Add a `--cpp17` option to the build scripts to force using `/std:c++17`
on Win32 MSVC. This sets a GN argument called `std_cpp17` to true in
`webrtc/windows/templates/gns/args.gn` if that flag is set.